### PR TITLE
Add subcommands to support blackout periods

### DIFF
--- a/alerta/api.py
+++ b/alerta/api.py
@@ -125,6 +125,22 @@ class ApiClient(object):
 
         return self._delete('/heartbeat/%s' % heartbeatid)
 
+    def blackout_alerts(self, blackout):
+        """
+        Define a blackout period
+        """
+        return self._post('/blackout', data=json.dumps(blackout))
+
+    def get_blackouts(self):
+        """
+        Get list of blackouts
+        """
+        return self._get('/blackouts')
+
+    def delete_blackout(self, blackoutid):
+
+        return self._delete('/blackout/%s' % blackoutid)
+
     def get_status(self):
 
         return self._get('/management/status')

--- a/alerta/shell.py
+++ b/alerta/shell.py
@@ -568,6 +568,14 @@ class AlertCommand(object):
         for blackout in blackouts:
             start_time = datetime.strptime(blackout['startTime'], '%Y-%m-%dT%H:%M:%S.%fZ')
             tz = pytz.timezone(args.timezone)
+
+            if args.purge and blackout['status'] == 'expired':
+                response = self.api.delete_blackout(blackout['id'])
+                if response['status'] == 'ok':
+                    blackout['status'] = 'deleted'
+                else:
+                    blackout['status'] = 'error'
+
             print('{:<8} {:<16} {:16} {:16} {:16} {:16} {:24} {:8} {} {}s'.format(
                 blackout['id'][:8],
                 blackout.get('environment', '*'),
@@ -1200,7 +1208,7 @@ class AlertaShell(object):
             usage='alerta [OPTIONS] blackouts [-h]'
         )
         parser_blackouts.add_argument(
-            '--delete-expired',
+            '--purge',
             default=False,
             help='Delete all expired blackout periods',
             action='store_true'


### PR DESCRIPTION
Create a new blackout period using `alerta blackout`...

**Example**
```
$ alerta --profile development blackout -E Infra -S Alerta --start 2015-09-19T17:45:00Z --duration 7200
```

Display all blackout periods, and purge expired ones, using `alerta blackouts`...

**Example**
```
$ alerta --profile development blackouts
ID       ENVIRONMENT      SERVICE          RESOURCE         EVENT            GROUP            TAGS                     STATUS   START               DURATION
77b486e7 Development      *                *                *                *                foo bar baz              active   2015/09/09 18:45:11 3600s
7ce39efc Infra            Alerta           *                *                *                *                        pending  2015/09/19 18:45:00 7200s
dc4d2a59 Production       *                web01            NodeDown         *                *                        expired  2015/09/09 19:38:41 5s
```