### PR TITLE
Bug fix - Using os.uname on Windows

### DIFF
--- a/alerta/alert.py
+++ b/alerta/alert.py
@@ -1,5 +1,6 @@
 
 import os
+import platform
 import sys
 import time
 import datetime
@@ -42,7 +43,7 @@ class Alert(object):
         self.text = kwargs.get('text', None) or ""
         self.tags = kwargs.get('tags', None) or list()
         self.attributes = kwargs.get('attributes', None) or dict()
-        self.origin = kwargs.get('origin', None) or '%s/%s' % (prog, os.uname()[1])
+        self.origin = kwargs.get('origin', None) or '%s/%s' % (prog, platform.uname()[1])
         self.event_type = kwargs.get('event_type', kwargs.get('type', None)) or "exceptionAlert"
         self.create_time = kwargs.get('create_time', None) or datetime.datetime.utcnow()
         self.receive_time = None


### PR DESCRIPTION
When using python-alerta (api or CLI) from Windows and you don't specify
an origin then a Python Exception is thrown (AttributeError: 'module'
object has no attribute 'uname').
Upon investigation it is the os.uname() (alert.py line 46) call that
cause it as os.uname() is only available on Unix.
(https://docs.python.org/2/library/os.html#os.uname).
Suggestion: use cross-platform 'platform' module instead
(https://docs.python.org/2/library/platform.html#platform.uname)