### PR TITLE
Use portable platform lib instead of os.uname()

### DIFF
--- a/alerta/alert.py
+++ b/alerta/alert.py
@@ -1,7 +1,7 @@
 
 import os
-import platform
 import sys
+import platform
 import time
 import datetime
 import pytz
@@ -190,7 +190,7 @@ class AlertDocument(object):
         self.text = text or ""
         self.tags = tags or list()
         self.attributes = attributes or dict()
-        self.origin = origin or '%s/%s' % (prog, os.uname()[1])
+        self.origin = origin or '%s/%s' % (prog, platform.uname()[1])
         self.event_type = event_type or 'exceptionAlert'
         self.create_time = create_time or datetime.datetime.utcnow()
         self.timeout = timeout or DEFAULT_TIMEOUT

--- a/alerta/heartbeat.py
+++ b/alerta/heartbeat.py
@@ -1,6 +1,7 @@
 
 import os
 import sys
+import platform
 import time
 import datetime
 import pytz
@@ -20,7 +21,7 @@ class Heartbeat(object):
     def __init__(self, origin=None, tags=None, create_time=None, timeout=None, customer=None):
 
         self.id = str(uuid4())
-        self.origin = origin or '%s/%s' % (prog, os.uname()[1])
+        self.origin = origin or '%s/%s' % (prog, platform.uname()[1])
         self.tags = tags or list()
         self.event_type = 'Heartbeat'
         self.create_time = create_time or datetime.datetime.utcnow()


### PR DESCRIPTION
Missed a few `os.uname()` references in #18