### PR TITLE
Allow admin users to set user passwords

### DIFF
--- a/alerta/api.py
+++ b/alerta/api.py
@@ -141,6 +141,10 @@ class ApiClient(object):
 
         return self._delete('/blackout/%s' % blackoutid)
 
+    def update_user(self, user, password):
+
+        return self._put('/user/%s' % user, data=json.dumps({"password": password}))
+
     def get_status(self):
 
         return self._get('/management/status')
@@ -172,6 +176,18 @@ class ApiClient(object):
         LOG.debug('Request Body: %s', data)
 
         response = self.session.post(url, data=data, auth=ApiAuth(self.key), headers=headers)
+
+        return response.json()
+
+    def _put(self, path, data=None):
+
+        url = self.endpoint + path
+        headers = {'Content-Type': 'application/json'}
+
+        LOG.debug('Request Headers: %s', headers)
+        LOG.debug('Request Body: %s', data)
+
+        response = self.session.put(url, data=data, auth=ApiAuth(self.key), headers=headers)
 
         return response.json()
 

--- a/alerta/shell.py
+++ b/alerta/shell.py
@@ -594,6 +594,19 @@ class AlertCommand(object):
                 blackout['duration']
             ))
 
+    def user(self, args):
+
+        if args.password:
+            response = self.api.update_user(args.user, args.password)
+            if response['status'] == 'ok':
+                print('Password reset OK.')
+            else:
+                LOG.error(response['message'])
+                sys.exit(1)
+        else:
+            LOG.error('Only change password supported at present.')
+            sys.exit(1)
+
     @staticmethod
     def _build(filters, from_date=None, to_date=None):
 
@@ -1260,6 +1273,23 @@ class AlertaShell(object):
             action='store_true'
         )
         parser_heartbeats.set_defaults(func=cli.heartbeats)
+
+        parser_user = subparsers.add_parser(
+            'user',
+            help='Manage user details (Basic Auth only).',
+            usage='alerta [OPTIONS] user --user-name USER [--password PASSWORD]'
+        )
+        parser_user.add_argument(
+            '--user-name',
+            dest='user',
+            required=True,
+            help='User name'
+        )
+        parser_user.add_argument(
+            '--password',
+            help='New password'
+        )
+        parser_user.set_defaults(func=cli.user)
 
         parser_status = subparsers.add_parser(
             'status',


### PR DESCRIPTION
Requires version 4.6.9 of the `alerta` command-line tool...
```
alerta --profile development user --user-name me@example.com --password p8ssw0rd
```

See guardian/alerta#139