### PR TITLE
Only call top exit handler during init screen

### DIFF
--- a/alerta/top.py
+++ b/alerta/top.py
@@ -254,6 +254,7 @@ class Screen(object):
         self.w = UpdateThread(endpoint=self.endpoint, key=self.key)
         self.w.start()
 
+        self.register_exit_handlers()
         self.mainloop()
 
     def mainloop(self):
@@ -559,14 +560,14 @@ class Screen(object):
             # Redraw the screen on resize
             self._redraw()
 
+    def exit_handler(signum, frame):
 
-def exit_handler(signum, frame):
+        curses.echo()
+        curses.nocbreak()
+        curses.endwin()
+        sys.exit(0)
 
-    curses.echo()
-    curses.nocbreak()
-    curses.endwin()
-    sys.exit(0)
-
-# Register exit signals
-signal.signal(signal.SIGTERM, exit_handler)
-signal.signal(signal.SIGINT, exit_handler)
+    def register_exit_handlers(self):
+        # Register exit signals
+        signal.signal(signal.SIGTERM, self.exit_handler)
+        signal.signal(signal.SIGINT, self.exit_handler)


### PR DESCRIPTION
```
^C2016-02-21 22:04:49,132 - alerta.shell - ERROR - must call initscr() first
Traceback (most recent call last):
  File "build/bdist.macosx-10.9-x86_64/egg/alerta/shell.py", line 1351, in main
    AlertaShell().run()
  File "build/bdist.macosx-10.9-x86_64/egg/alerta/shell.py", line 1339, in run
    args.func(args)
  File "build/bdist.macosx-10.9-x86_64/egg/alerta/shell.py", line 219, in watch
    time.sleep(2)
  File "build/bdist.macosx-10.9-x86_64/egg/alerta/top.py", line 565, in exit_handler
    curses.echo()
error: must call initscr() first
```