### PR TITLE
Raise exception if timeout not an integer

### DIFF
--- a/alerta/alert.py
+++ b/alerta/alert.py
@@ -144,12 +144,15 @@ class Alert(object):
                     alert[k] = datetime.datetime.strptime(v, '%Y-%m-%dT%H:%M:%S.%fZ')
                 except ValueError as e:
                     raise ValueError('Could not parse date time string: %s' % e)
-            if k in ['correlate', 'service', 'tags']:
+            elif k in ['correlate', 'service', 'tags']:
                 if not isinstance(alert[k], list):
                     raise ValueError('Attribute must be list: %s' % k)
-            if k == 'attributes':
+            elif k == 'attributes':
                 if not isinstance(alert[k], dict):
                     raise ValueError('Attribute must be name/value pairs: attributes')
+            elif k == 'timeout':
+                if not isinstance(alert[k], int):
+                    raise ValueError('Timeout must be an integer')
 
         return Alert(
             resource=alert.get('resource', None),

--- a/tests/test_alert.py
+++ b/tests/test_alert.py
@@ -101,3 +101,14 @@ class TestAlert(unittest.TestCase):
             timeout=0
         )
         self.assertEquals(alert.timeout, 0)
+
+    def test_parse_alert(self):
+
+        def parse_attribute(k, v):
+            return Alert.parse_alert('{"resource": "%s", "event": "%s", "%s": %s}' % (self.RESOURCE, self.EVENT, k, v))
+
+        self.assertRaises(ValueError, parse_attribute, "service", "\"Common\"")
+        self.assertEqual(parse_attribute("service", "[\"Common\"]").service, self.SERVICE)
+
+        self.assertRaises(ValueError, parse_attribute, "timeout", "\"3600\"")
+        self.assertEqual(parse_attribute("timeout", self.TIMEOUT).timeout, self.TIMEOUT)


### PR DESCRIPTION

```
$ http POST :8080/alert 'Authorization: Key 6IcDbBodwdLUSgez5wsNjEucMjoiBkAOatxJgQgL' status=unknown resource=r1 event=e4 environment=Development service:='["a","b"]' timeout=5
POST /alert HTTP/1.1
Accept: application/json
Accept-Encoding: gzip, deflate
Authorization:  Key 6IcDbBodwdLUSgez5wsNjEucMjoiBkAOatxJgQgL
Connection: keep-alive
Content-Length: 123
Content-Type: application/json
Host: localhost:8080
User-Agent: HTTPie/0.9.3

{
    "environment": "Development",
    "event": "e4",
    "resource": "r1",
    "service": [
        "a",
        "b"
    ],
    "status": "unknown",
    "timeout": "5"
}

HTTP/1.0 400 BAD REQUEST
Content-Length: 67
Content-Type: application/json
Date: Wed, 11 May 2016 09:30:32 GMT
Server: Werkzeug/0.10.4 Python/2.7.9

{
    "message": "Timeout must be an integer",
    "status": "error"
}
```