### PR TITLE
Add history type column to alerta history list

### DIFF
--- a/alerta/shell.py
+++ b/alerta/shell.py
@@ -270,10 +270,11 @@ class AlertCommand(object):
             if 'severity' in hist:
                 if args.color:
                     line_color = _COLOR_MAP.get(hist['severity'], _COLOR_MAP['unknown'])
-                print(line_color + '%s|%s|%s|%s|%-5s|%-10s|%-18s|%s|%s|%s|%s' % (
+                print(line_color + '%s|%s|%s|%s|%-5s|%-10s|%-18s|%s|%s|%s|%s|%s' % (
                     hist['id'][0:8],
                     update_time.strftime('%Y/%m/%d %H:%M:%S'),
                     hist['severity'],
+                    hist.get('type', 'unknown'),
                     hist['customer'],
                     hist['environment'],
                     ','.join(hist['service']),
@@ -285,10 +286,11 @@ class AlertCommand(object):
                 ) + end_color)
 
             if 'status' in hist:
-                print(line_color + '%s|%s|%s|%s|%-5s|%-10s|%-18s|%s|%s|%s|%s' % (
+                print(line_color + '%s|%s|%s|%s|%-5s|%-10s|%-18s|%s|%s|%s|%s|%s' % (
                     hist['id'][0:8],
                     update_time.strftime('%Y/%m/%d %H:%M:%S'),
                     hist['status'],
+                    hist.get('type', 'unknown'),
                     hist['customer'],
                     hist['environment'],
                     ','.join(hist['service']),


### PR DESCRIPTION
```
$ alerta history
75b46be6|2016/05/19 18:43:40|minor|external|None |Production|Foo               |NewResource2|Misc|NewEvent|n/a|MINOR: test1
75b46be6|2016/05/19 18:43:45|ok|external|None |Production|Foo               |NewResource2|Misc|NewEvent|n/a|OK: test1
75b46be6|2016/05/19 18:43:45|closed|internal|None |Production|Foo               |NewResource2|Misc|NewEvent|n/a|correlated alert status change
75b46be6|2016/05/19 18:44:09|ack|external|None |Production|Foo               |NewResource2|Misc|NewEvent|n/a|status change via console
```

See guardian/alerta#196